### PR TITLE
feat: integrate edit profile with backend

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "@testing-library/user-event": "~12.6.3",
         "axios": "~0.21.1",
         "js-cookie": "~2.2.1",
-        "moment": "^2.29.1",
+        "moment": "~2.29.1",
         "node-sass": "~5.0.0",
         "react": "~17.0.1",
         "react-dom": "~17.0.1",

--- a/client/src/components/MyProfile/MyProfileData.js
+++ b/client/src/components/MyProfile/MyProfileData.js
@@ -1,15 +1,26 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { Header, Button } from "semantic-ui-react";
 import EditProfileModal from "./EditProfileModal";
+import { Context } from "../../Context";
 import "./MyProfilePage.scss";
 
 const MyProfileData = () => {
+  const context = useContext(Context);
+
+  let nameToRender = "Loading...";
+
+  if (context.user && context.user.displayName) {
+    nameToRender = context.user.displayName;
+  } else if (context.user && context.user.username) {
+    nameToRender = context.user.username;
+  }
+
   return (
     <div>
       <div className="profile-top-section">
         <div className="display-name-heading">
           <Header as="h1" floated="left">
-            Test User
+            {nameToRender}
           </Header>
           <EditProfileModal />
         </div>
@@ -18,7 +29,9 @@ const MyProfileData = () => {
           <Header as="h4" floated="left">
             GitHub:
           </Header>
-          <span>bui1</span>
+          <span>
+            {context.user && context.user.github ? context.user.github : "N/A"}
+          </span>
         </div>
       </div>
 

--- a/client/src/components/MyProfile/MyProfilePage.scss
+++ b/client/src/components/MyProfile/MyProfilePage.scss
@@ -8,7 +8,7 @@
     background: #ffffff;
     box-shadow: 2px 4px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 20px;
-    width: 561px;
+    width: 500px;
     height: max-content;
   }
 
@@ -65,7 +65,7 @@
 
 .ui.large.form.edit-profile-form {
   width: 100%;
-  margin-top: 25px;
+  margin-top: 15px;
   padding-left: 20px;
   padding-right: 20px;
 }


### PR DESCRIPTION
* Edit profile works now with displayname and github username

Profile card is changed to use displayname if it exists otherwise uses username. Github stays as "N/A" if user has not set it yet.
![image](https://user-images.githubusercontent.com/20286010/108569689-90e74280-72c9-11eb-8948-4f3fca78a309.png)

Resolves #40 