### PR TITLE
feat: get all public posts

### DIFF
--- a/server/konnection/urls.py
+++ b/server/konnection/urls.py
@@ -16,9 +16,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.urls.conf import include
+from posts import views as posts_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('service/author/', include('posts.urls')),
     path('service/author/', include('author.urls')),
+    path('service/public/', posts_views.PublicPostView.as_view(), name='public'),
 ]

--- a/server/konnection/urls.py
+++ b/server/konnection/urls.py
@@ -20,7 +20,6 @@ from posts import views as posts_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('service/author/', include('posts.urls')),
+    path('service/', include('posts.urls')),
     path('service/author/', include('author.urls')),
-    path('service/public/', posts_views.PublicPostView.as_view(), name='public'),
 ]

--- a/server/konnection/urls.py
+++ b/server/konnection/urls.py
@@ -22,5 +22,4 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('service/', include('posts.urls')),
     path('service/author/', include('author.urls')),
-    path('service/public/', posts_views.PublicPostView.as_view(), name='public'),
 ]

--- a/server/posts/tests/test_create_post_endpoint.py
+++ b/server/posts/tests/test_create_post_endpoint.py
@@ -338,7 +338,7 @@ class TestPublicPostEndpoint(TestCase):
             password= 'password'
         )
         self.public_url = reverse(
-            'public',
+            'posts:public',
         )
         self.create_post_url = reverse(
             'posts:create', kwargs={'author_id': self.author.id}

--- a/server/posts/tests/test_create_post_endpoint.py
+++ b/server/posts/tests/test_create_post_endpoint.py
@@ -340,6 +340,7 @@ class TestPublicPostEndpoint(TestCase):
         self.public_url = reverse(
             'posts:public',
         )
+        self.assertEqual(self.public_url, '/service/public/')
         self.create_post_url = reverse(
             'posts:create', kwargs={'author_id': self.author.id}
         )

--- a/server/posts/urls.py
+++ b/server/posts/urls.py
@@ -7,5 +7,5 @@ app_name = 'posts'
 urlpatterns = [
     path('author/<uuid:author_id>/posts/', views.CreatePostView.as_view(), name='create'),
     path('author/<uuid:author_id>/posts/<uuid:pk>/', views.UpdatePostView.as_view(), name='update'),
-    path('service/public/', views.PublicPostView.as_view(), name='public'),
+    path('public/', views.PublicPostView.as_view(), name='public'),
 ] 

--- a/server/posts/urls.py
+++ b/server/posts/urls.py
@@ -5,6 +5,7 @@ from posts import views
 app_name = 'posts'
 
 urlpatterns = [
-    path('<uuid:author_id>/posts/', views.CreatePostView.as_view(), name='create'),
-    path('<uuid:author_id>/posts/<uuid:pk>/', views.UpdatePostView.as_view(), name='update')
+    path('author/<uuid:author_id>/posts/', views.CreatePostView.as_view(), name='create'),
+    path('author/<uuid:author_id>/posts/<uuid:pk>/', views.UpdatePostView.as_view(), name='update'),
+    path('service/public/', views.PublicPostView.as_view(), name='public'),
 ] 

--- a/server/posts/views.py
+++ b/server/posts/views.py
@@ -112,3 +112,13 @@ class CreatePostView(generics.ListCreateAPIView):
     def perform_create(self, serializer):
         request_author_id = self.kwargs['author_id']
         serializer.save(author=mainModels.Author.objects.get(id=self.request.user.id))
+
+
+# service/public/
+class PublicPostView(generics.ListAPIView):
+    serializer_class = PostSerializer
+
+    # GET: get all public and not unlisted Post
+    def get_queryset(self):
+        queryset = Post.objects.filter(visibility=Post.PUBLIC, unlisted=False)
+        return queryset


### PR DESCRIPTION
#64 Get all public and listed posts of everyone using /service/public/, no authentication required.
![image](https://user-images.githubusercontent.com/35179885/109481332-d9290200-7a39-11eb-8fae-d813a1d41a58.png)
