### PR TITLE
[n/a] feat: endpoint to retrieve all authors 

### DIFF
--- a/server/author/tests/test_create_author_endpoint.py
+++ b/server/author/tests/test_create_author_endpoint.py
@@ -147,7 +147,6 @@ class TestAuthGetAuthorEndpoint(TestCase):
     """Test API(GET)://service/author/{AUTHOR_ID}/"""
     def setUp(self):
         self.client = APIClient()
-        print(AUTH_USER_URL)
         
     def test_get_author_endpoint_with_auth(self):
         """Test retrieving author profile if user is logged in"""
@@ -314,12 +313,13 @@ class TestGetAllAuthorsEndpoint(TestCase):
             password='abcpwd',
             adminApproval= True,
             type=utils.UserType.superuser.value,
-            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3e').int,
+            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3e'),
         )
         create_author(
             username='abc002',
             password='abcpwd',
-            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3f').int,
+            adminApproval= True,
+            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3f'),
         )
         self.client.force_authenticate(user)
 
@@ -327,6 +327,28 @@ class TestGetAllAuthorsEndpoint(TestCase):
        
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(len(res.data), 1)
+
+    def test_get_all_authors_endpoint_not_return_unapproved(self):
+        """Test retrieving all authors profile list exclude not admin approved user"""
+        user = create_author(
+            username='abc001',
+            password='abcpwd',
+            adminApproval= True,
+            type=utils.UserType.superuser.value,
+            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3e'),
+        )
+        create_author(
+            username='abc002',
+            password='abcpwd',
+            adminApproval= False,
+            id=uuid.UUID('77f1df52-4b43-11e9-910f-b8ca3a9b9f3f'),
+        )
+        self.client.force_authenticate(user)
+
+        res = self.client.get(ALL_AUTHOR_URL)
+       
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(res.data), 0)
 
     def test_get_all_authors_endpoint_without_admin_approval(self):
         """Test get all authors endpoint is safeguard by admin approved"""

--- a/server/author/urls.py
+++ b/server/author/urls.py
@@ -5,8 +5,9 @@ from author import views
 app_name = 'author'
 
 urlpatterns = [
-    path('create/', views.CreateAuthorView.as_view(), name='create'),
-    path('auth/', views.AuthAuthorView.as_view(), name='auth'),
-    path('me/', views.MyProfileView.as_view(), name = 'me'),
-    path('<slug:pk>/', views.AuthorProfileView.as_view(), name = 'authors'),
+    path('author/create/', views.CreateAuthorView.as_view(), name='create'),
+    path('author/auth/', views.AuthAuthorView.as_view(), name='auth'),
+    path('author/me/', views.MyProfileView.as_view(), name = 'me'),
+    path('authors/', views.AllAuthorsView.as_view(), name = 'all'),
+    path('author/<slug:pk>/', views.AuthorProfileView.as_view(), name = 'authors'),
 ]

--- a/server/author/views.py
+++ b/server/author/views.py
@@ -58,3 +58,16 @@ class MyProfileView(generics.RetrieveAPIView):
             raise AuthenticationFailed(detail ={"error": ["User has not been approved by admin"]})
             
         return self.request.user
+
+class AllAuthorsView(generics.ListAPIView):
+    """Get all authors in the system"""
+    serializer_class = AuthorProfileSerializer
+    authenticate_classes = (authentication.TokenAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
+    
+    def get_queryset(self):
+        if not self.request.user.adminApproval:
+            raise AuthenticationFailed(
+                detail={"error": ["User has not been approved by admin"]})
+        
+        return get_user_model().objects.filter(type='author')

--- a/server/author/views.py
+++ b/server/author/views.py
@@ -70,4 +70,4 @@ class AllAuthorsView(generics.ListAPIView):
             raise AuthenticationFailed(
                 detail={"error": ["User has not been approved by admin"]})
         
-        return get_user_model().objects.filter(type='author')
+        return get_user_model().objects.filter(type='author', adminApproval=True)

--- a/server/konnection/urls.py
+++ b/server/konnection/urls.py
@@ -21,8 +21,12 @@ from posts import views as posts_views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('service/', include('posts.urls')),
+<<<<<<< HEAD
     path('service/author/', include('comments.urls')),
     path('service/author/', include('author.urls')),
+=======
+    path('service/', include('author.urls')),
+>>>>>>> implement for get all authors
     path('service/author/', include('inbox.urls')),
     path('service/author/', include('followers.urls')),
 ]

--- a/server/konnection/urls.py
+++ b/server/konnection/urls.py
@@ -21,12 +21,8 @@ from posts import views as posts_views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('service/', include('posts.urls')),
-<<<<<<< HEAD
     path('service/author/', include('comments.urls')),
-    path('service/author/', include('author.urls')),
-=======
     path('service/', include('author.urls')),
->>>>>>> implement for get all authors
     path('service/author/', include('inbox.urls')),
     path('service/author/', include('followers.urls')),
 ]

--- a/server/main/models.py
+++ b/server/main/models.py
@@ -2,9 +2,6 @@ from django.db import models
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.conf import settings
 
-from django.dispatch import receiver
-from django.db.models.signals import post_save
-
 import uuid
 import re
 from main import utils
@@ -22,7 +19,7 @@ class UserManager(BaseUserManager):
         user=self.create_author(username, password)
         user.is_superuser=True
         user.is_staff=True
-        user.type=utils.UserType.superuser
+        user.type=utils.UserType.superuser.value
         user.save(using=self._db)
 
         return user
@@ -51,6 +48,7 @@ class Author(AbstractBaseUser, PermissionsMixin):
 class Followers(models.Model):
     author = models.ForeignKey(Author, related_name="followers", on_delete=models.CASCADE)
     followers = models.ManyToManyField(Author, related_name='author_followers')
+   
 
     def friends(self):
         list = []


### PR DESCRIPTION
# Summary 
This pr introduced a new endpoint to be used for retrieving all authors and peer-to-peer server connection.

**Documentation**:  [followers wikipage](https://github.com/C404TEAMW21/CMPUT404_PROJECT/wiki/Followers)

## Sub-tasks 
- [x] All author endpoint (excluding superuser and not admin approved author)
- [x] Refrain the users from using the endpoint if their account is not admin approved
- [x] Unit testing
- [x] Cleaned up old code 
- [x] Update documentation 

## Resolve
Resolve n/a