### PR TITLE
turn off admin apporval

### DIFF
--- a/server/author/tests/test_create_author_endpoint.py
+++ b/server/author/tests/test_create_author_endpoint.py
@@ -127,20 +127,21 @@ class TestAuthAuthorEndpoint(TestCase):
 
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertNotIn('token', res.data)
+    
+    # TODO: Remove when admin approval default is set to false
+    # def test_user_without_admin_approval(self):
+    #     """Test returning error when logging into an
+    #     account that is without admin approval"""
+    #     payload={
+    #         'username':'abc001',
+    #         'password':'abcpwd',
+    #     }
+    #     create_author(**payload)
 
-    def test_user_without_admin_approval(self):
-        """Test returning error when logging into an
-        account that is without admin approval"""
-        payload={
-            'username':'abc001',
-            'password':'abcpwd',
-        }
-        create_author(**payload)
+    #     res = self.client.post(AUTH_USER_URL, payload)
 
-        res = self.client.post(AUTH_USER_URL, payload)
-
-        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertNotIn('token', res.data)
+    #     self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+    #     self.assertNotIn('token', res.data)
 
 
 class TestAuthGetAuthorEndpoint(TestCase):

--- a/server/main/models.py
+++ b/server/main/models.py
@@ -39,7 +39,7 @@ class Author(AbstractBaseUser, PermissionsMixin):
     url = models.CharField(max_length=255, default='')
     github = models.CharField(max_length=255, default='', blank=True)
 
-    adminApproval = models.BooleanField(default=False)
+    adminApproval = models.BooleanField(default=True)
     username = models.CharField(max_length=25, unique=True)
     is_staff = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)


### PR DESCRIPTION
# Summary 
This pr is to set admin approval default to True, in order to alleviate the hassle of approving users. It will be set back to false before the demo. 