### PR TITLE
Get remote post will return a Post JSON

### DIFF
--- a/server/posts/urls.py
+++ b/server/posts/urls.py
@@ -6,7 +6,7 @@ app_name = 'posts'
 
 urlpatterns = [
     path('author/<uuid:author_id>/posts/', views.CreatePostView.as_view(), name='create'),
-    path('author/<uuid:author_id>/posts/<uuid:pk>/', views.UpdatePostView.as_view(), name='update'),
+    path('author/<str:author_id>/posts/<str:pk>/', views.UpdatePostView.as_view(), name='update'),
     path('author/<uuid:author_id>/posts/<uuid:pk>/share/', views.SharePostView.as_view(), name='share'),
     path('public/', views.PublicPostView.as_view(), name='public'),
 ] 


### PR DESCRIPTION
When GET-ing a remote Post that lives in Inbox using `api/author/{AUTHOR_ID}/posts/{POST_ID}`, it will now search for this remote Post in the requester's Inbox, if not found, return 404

- [x] Changed AUTHOR_ID and POST_ID from uuid to str in urls.py (Django will automatically return 404 if uuid not found)
- [x] Update `api/author/{AUTHOR_ID}/posts/{POST_ID}` endpoint to search in Inbox
- [x] Update POST, DELETE, PUT to cast str to uuid to search
- [x] Fix tests caused by ^ 