### PR TITLE
fix KeyError in Inbox when searching for remote Post

### DIFF
--- a/server/posts/urls.py
+++ b/server/posts/urls.py
@@ -7,6 +7,6 @@ app_name = 'posts'
 urlpatterns = [
     path('author/<uuid:author_id>/posts/', views.CreatePostView.as_view(), name='create'),
     path('author/<str:author_id>/posts/<str:pk>/', views.UpdatePostView.as_view(), name='update'),
-    path('author/<uuid:author_id>/posts/<uuid:pk>/share/', views.SharePostView.as_view(), name='share'),
+    path('author/<str:author_id>/posts/<str:pk>/share/', views.SharePostView.as_view(), name='share'),
     path('public/', views.PublicPostView.as_view(), name='public'),
 ] 

--- a/server/posts/views.py
+++ b/server/posts/views.py
@@ -281,7 +281,11 @@ class SharePostView(generics.CreateAPIView):
                 return Response({'error': 'Inbox not found!'},
                                 status=status.HTTP_404_NOT_FOUND)
             for item in sharer_items:
-                if str(post_id) == item['id']:
+                try:
+                    item_id = item['id']
+                except KeyError:
+                    continue
+                if post_id in item_id:
                     post_data = item
         if post_data == None:
             return Response({'error': 'Post not found!'},


### PR DESCRIPTION
Fix issue when searching in Inbox, it tries to search for 'id', where Like objects do not have an 'id' attribute and cause a KeyError.